### PR TITLE
Initialize parser pool

### DIFF
--- a/src/main/java/org/opensciencegrid/authz/xacml/common/OSGSAMLBootstrap.java
+++ b/src/main/java/org/opensciencegrid/authz/xacml/common/OSGSAMLBootstrap.java
@@ -80,6 +80,8 @@ public class OSGSAMLBootstrap extends DefaultBootstrap {
         initializeArtifactBuilderFactories();
 
         initializeGlobalSecurityConfiguration();
+
+        initializeParserPool();
     }
 
 }


### PR DESCRIPTION
Motivation:

It appears that OSGSAMLBootstrap#bootstrap is supposed to replace
DefaultBootstrap#bootstrap, but in contrast to the latter the former fails to
initialize the parser pool. I suspect the parser pool initialization was added
during an upgrade of opensaml library and wasn't mirrored in the xacml client
library.

Modification:

Add a call to initializeParserPool during bootstrapping.

Result:

No null pointer exception when using the XACML client.
