### PR TITLE
Port to CANL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>privilege-xacml</artifactId>
 	<packaging>jar</packaging>
 	<name>privilege-xacml</name>
-	<version>2.6.6</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<url>http://maven.apache.org</url>
 
 	<repositories>
@@ -178,16 +178,6 @@
 			<version>2.4.1</version>
 		</dependency>
 		<dependency>
-			<groupId>org.jglobus</groupId>
-			<artifactId>ssl-proxies</artifactId>
-			<version>2.0.6</version>
-		</dependency>
-		<dependency>
-			<groupId>org.jglobus</groupId>
-			<artifactId>gss</artifactId>
-			<version>2.0.6</version>
-		</dependency>
-		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
 			<version>1.5.2</version>
@@ -213,7 +203,7 @@
 			<artifactId>xmlsec</artifactId>
 			<version>1.4.1</version>
 		</dependency>
-		<!--provided scope--> 
+		<!--provided scope-->
 		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
@@ -229,30 +219,17 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!--runtime scope--> 
-		<dependency>
-			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk16</artifactId>
-			<version>1.46</version>
-			<scope>provided</scope>
-		</dependency>  
+		<!--runtime scope-->
 		<dependency>
 			<groupId>org.italiangrid</groupId>
 			<artifactId>voms-api-java</artifactId>
-			<version>2.0.8</version>
-			<scope>provided</scope>
-		</dependency>	   
-		<dependency>
-			<groupId>emi</groupId>
-			<artifactId>emi-trustmanager</artifactId>
-			<version>3.0.3</version>
+			<version>3.0.5</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>emi</groupId>
-			<artifactId>emi-trustmanager-axis</artifactId>
-			<version>1.0.1</version>
-			<scope>runtime</scope>
+			<groupId>eu.eu-emi.security</groupId>
+			<artifactId>canl</artifactId>
+			<version>1.3.3</version>
 		</dependency>
 		<dependency>
 			<groupId>velocity</groupId>

--- a/src/main/java/org/opensciencegrid/authz/xacml/client/XACMLX509Test.java
+++ b/src/main/java/org/opensciencegrid/authz/xacml/client/XACMLX509Test.java
@@ -1,13 +1,11 @@
 package org.opensciencegrid.authz.xacml.client;
 
+import eu.emi.security.authn.x509.impl.PEMCredential;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.glite.voms.VOMSAttribute;
-import org.globus.gsi.GlobusCredential;
-import org.globus.gsi.gssapi.GSSConstants;
-import org.gridforum.jgss.ExtendedGSSContext;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSException;
+import org.italiangrid.voms.VOMSAttribute;
 import org.opensciencegrid.authz.xacml.common.LocalId;
 import org.opensciencegrid.authz.xacml.common.X509CertUtil;
 import org.opensciencegrid.authz.xacml.common.XACMLConstants;
@@ -22,9 +20,9 @@ public class XACMLX509Test {
 
     public static void main(String[] args) {
 
-        GlobusCredential cred = null;
+        PEMCredential cred = null;
         try {
-            cred = new GlobusCredential(getProxyFile());
+            cred = new PEMCredential(getProxyFile(), (char[]) null);
             System.setProperty("X509_PROXY_FILE", getProxyFile());
         } catch (Exception e) {
             logger.error("Caught exception in context creation. " + e.getMessage());
@@ -111,7 +109,7 @@ public class XACMLX509Test {
         }
         if (vomsAttr!=null) {
             VO = vomsAttr.getVO();
-            String X500IssuerName = vomsAttr.getAC().getIssuer().toString();
+            String X500IssuerName = vomsAttr.getIssuer().toString();
             VOMSSigningSubject = X509CertUtil.toGlobusDN(X500IssuerName);
         }
 

--- a/src/main/java/org/opensciencegrid/authz/xacml/common/X509CertUtil.java
+++ b/src/main/java/org/opensciencegrid/authz/xacml/common/X509CertUtil.java
@@ -70,10 +70,9 @@ public class X509CertUtil {
 
     public static Date getLatestNotBefore(X509Certificate[] chain) throws Exception {
         Date not_before=null;
-        for (int i=0; i<chain.length; i++) {
-            X509Certificate	testcert = chain[i];
+        for (X509Certificate testcert : chain) {
             Date test_not_before = testcert.getNotBefore();
-            if (not_before==null || test_not_before.after(not_before) ) {
+            if (not_before == null || test_not_before.after(not_before)) {
                 not_before = test_not_before;
             }
 
@@ -92,10 +91,9 @@ public class X509CertUtil {
 
     public static Date getEarliestNotAfter(X509Certificate[] chain) throws Exception {
         Date not_after=null;
-        for (int i=0; i<chain.length; i++) {
-            X509Certificate	testcert = chain[i];
+        for (X509Certificate testcert : chain) {
             Date test_not_after = testcert.getNotAfter();
-            if (not_after==null || test_not_after.before(not_after) ) {
+            if (not_after == null || test_not_after.before(not_after)) {
                 not_after = test_not_after;
             }
 
@@ -124,7 +122,7 @@ public class X509CertUtil {
     public static Collection <String> getFQANsFromX509Chain(X509Certificate[] chain, boolean validate) throws Exception {
         Collection <String> fqans=null;
         try {
-            List listOfAttributes = getVOMSAttributes(chain, validate);
+            List<VOMSAttribute> listOfAttributes = getVOMSAttributes(chain, validate);
             fqans = getFQANSfromVOMSAttributes(listOfAttributes);
         } catch(Exception ae ) {
             throw new Exception(ae.toString());
@@ -146,27 +144,23 @@ attribute : /cms/uscms/Role=cmsprod/Capability=NULL
    /cms/uscms/Role=cmsprod/Capability=NULL
 */
 
-    public static LinkedHashSet<String> getFQANSfromVOMSAttributes(List listOfAttributes) {
+    public static LinkedHashSet<String> getFQANSfromVOMSAttributes(List<VOMSAttribute> listOfAttributes) {
         LinkedHashSet<String> fqans = new LinkedHashSet <String> ();
 
-        Iterator i = listOfAttributes.iterator();
-        while (i.hasNext()) {
-            VOMSAttribute vomsAttribute = (VOMSAttribute) i.next();
-            List<String> listOfFqans = vomsAttribute.getFQANs();
-            Iterator<String> j = listOfFqans.iterator();
-            while (j.hasNext()) {
-                String attr = j.next();
-                if(attr.endsWith(capnull))
-                attr = attr.substring(0, attr.length() - capnulllen);
-                if(attr.endsWith(rolenull))
-                attr = attr.substring(0, attr.length() - rolenulllen);
-                Iterator k = fqans.iterator();
-                boolean issubrole=false;
-                while (k.hasNext()) {
-                  String fqanattr=(String) k.next();
-                  if (fqanattr.startsWith(attr)) {issubrole=true; break;}
+        for (VOMSAttribute vomsAttribute : listOfAttributes) {
+            for (String attr : vomsAttribute.getFQANs()) {
+                if (attr.endsWith(capnull))
+                    attr = attr.substring(0, attr.length() - capnulllen);
+                if (attr.endsWith(rolenull))
+                    attr = attr.substring(0, attr.length() - rolenulllen);
+                boolean issubrole = false;
+                for (String fqanattr : fqans) {
+                    if (fqanattr.startsWith(attr)) {
+                        issubrole = true;
+                        break;
+                    }
                 }
-                if(!issubrole) fqans.add(attr);
+                if (!issubrole) fqans.add(attr);
             }
         }
 
@@ -180,27 +174,16 @@ attribute : /cms/uscms/Role=cmsprod/Capability=NULL
         if(fqan.endsWith(rolenull))
                 fqan = fqan.substring(0, fqan.length() - rolenulllen);
 
-        List listOfAttributes = getVOMSAttributes(chain, false);
+        List<VOMSAttribute> listOfAttributes = getVOMSAttributes(chain, false);
 
-        Iterator i = listOfAttributes.iterator();
-        while (i.hasNext()) {
-            VOMSAttribute vomsAttribute = (VOMSAttribute) i.next();
+        for (VOMSAttribute vomsAttribute : listOfAttributes) {
             List<String> listOfFqans = vomsAttribute.getFQANs();
-            Iterator<String> j = listOfFqans.iterator();
-            while (j.hasNext()) {
-                String attr = j.next();
-                String attrtmp=attr;
-                if(attrtmp.endsWith(capnull))
-                    attrtmp = attrtmp.substring(0, attrtmp.length() - capnulllen);
-                if(attrtmp.endsWith(rolenull))
-                    attrtmp = attrtmp.substring(0, attrtmp.length() - rolenulllen);
-                //Iterator k = fqans.iterator();
-                //boolean issubrole=false;
-                //while (k.hasNext()) {
-                  //String fqanattr=(String) k.next();
-                  //if (fqanattr.startsWith(attrtmp)) {issubrole=true; break;}
-                //}
-                if(attrtmp.equals(fqan)) return vomsAttribute;
+            for (String attr : listOfFqans) {
+                if (attr.endsWith(capnull))
+                    attr = attr.substring(0, attr.length() - capnulllen);
+                if (attr.endsWith(rolenull))
+                    attr = attr.substring(0, attr.length() - rolenulllen);
+                if (attr.equals(fqan)) return vomsAttribute;
             }
         }
 

--- a/src/main/java/org/opensciencegrid/authz/xacml/common/X509CertUtil.java
+++ b/src/main/java/org/opensciencegrid/authz/xacml/common/X509CertUtil.java
@@ -1,37 +1,30 @@
 package org.opensciencegrid.authz.xacml.common;
 
 
+import eu.emi.security.authn.x509.X509CertChainValidatorExt;
+import eu.emi.security.authn.x509.X509Credential;
+import eu.emi.security.authn.x509.impl.OpensslNameUtils;
+import eu.emi.security.authn.x509.impl.PEMCredential;
+import eu.emi.security.authn.x509.proxy.ProxyUtils;
+import org.italiangrid.voms.VOMSAttribute;
+import org.italiangrid.voms.VOMSValidators;
+import org.italiangrid.voms.ac.VOMSACValidator;
+import org.italiangrid.voms.store.VOMSTrustStore;
+import org.italiangrid.voms.store.VOMSTrustStores;
+import org.italiangrid.voms.util.CertificateValidatorBuilder;
 
-import org.ietf.jgss.GSSContext;
-import org.ietf.jgss.GSSException;
-import org.ietf.jgss.GSSCredential;
-import org.ietf.jgss.GSSManager;
-import org.globus.gsi.X509Credential;
-import org.globus.gsi.CredentialException;
-import org.globus.gsi.TrustedCertificates;
-import org.globus.gsi.GSIConstants;
-import org.globus.gsi.bc.BouncyCastleUtil;
-import org.globus.gsi.gssapi.GlobusGSSCredentialImpl;
-import org.globus.gsi.gssapi.GSSConstants;
-import org.globus.gsi.gssapi.auth.NoAuthorization;
-import org.globus.gsi.gssapi.net.GssSocketFactory;
-import org.globus.gsi.gssapi.net.GssSocket;
-import org.gridforum.jgss.ExtendedGSSManager;
-import org.gridforum.jgss.ExtendedGSSContext;
-import org.bouncycastle.asn1.x509.TBSCertificateStructure;
-import org.glite.voms.*;
-import org.glite.voms.ac.AttributeCertificate;
-import org.glite.voms.ac.VOMSTrustStore;
-import org.glite.voms.ac.ACValidator;
-import org.glite.voms.ac.ACTrustStore;
-
-import java.net.Socket;
-import java.util.*;
-import java.security.cert.X509Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.CRLException;
 import java.io.IOException;
-import java.io.File;
+import java.security.KeyStoreException;
+import java.security.cert.CRLException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import static java.util.Arrays.asList;
 
 /**
  * X509CertUtil.java
@@ -44,14 +37,10 @@ public class X509CertUtil {
 
     public static String default_service_cert          = "/etc/grid-security/hostcert.pem";
     public static String default_service_key           = "/etc/grid-security/hostkey.pem";
-    public static String default_trusted_cacerts = "/etc/grid-security/certificates";
 
-    private static PKIStore caTrustStore=null;
-    private static VOMSTrustStore vomsTrustStore=null;
-    private static ACTrustStore acTrustStore=null;
-    private static VOMSValidator vomsValidator=null;
-    private static ACValidator acValidator=null;
-    private static PKIVerifier pkiVerifier=null;
+    private static X509CertChainValidatorExt certChainValidator;
+    private static VOMSACValidator vomsValidator;
+    private static PEMCredential hostCredential;
 
     private static int REFRESH_TIME_MS=20000;
 
@@ -59,65 +48,6 @@ public class X509CertUtil {
     public static final int capnulllen = capnull.length();
     public static final String rolenull ="/Role=NULL";
     public static final int rolenulllen = rolenull.length();
-
-    public static GSSContext getUserContext(String proxy_cert) throws GSSException {
-       return getUserContext(proxy_cert, default_trusted_cacerts);
-    }
-
-    public static GSSContext getUserContext(String proxy_cert, String service_trusted_certs) throws GSSException {
-
-	X509Credential userCredential;
-	try {
-            userCredential =new X509Credential(proxy_cert, proxy_cert);
-        } catch(CredentialException gce) {
-            throw new GSSException(GSSException.NO_CRED , 0,
-				   "could not load host globus credentials "+gce.toString());
-        } catch(IOException ioe) {
-	    throw new GSSException(GSSException.DEFECTIVE_CREDENTIAL,0,"Could not read cert or key " + ioe.getMessage() + "\n" + ioe.getCause());
-	}
-	 
-        GSSCredential cred = new GlobusGSSCredentialImpl(
-                userCredential,
-                GSSCredential.INITIATE_AND_ACCEPT);
-        TrustedCertificates trusted_certs =
-                TrustedCertificates.load(service_trusted_certs);
-        GSSManager manager = ExtendedGSSManager.getInstance();
-        ExtendedGSSContext context =
-                (ExtendedGSSContext) manager.createContext(cred);
-
-        context.setOption(GSSConstants.GSS_MODE, GSIConstants.MODE_GSI);
-        context.setOption(GSSConstants.TRUSTED_CERTIFICATES, trusted_certs);
-
-        return context;
-    }
-
-    public static Socket getGsiClientSocket(String host, int port, ExtendedGSSContext context) throws Exception {
-        Socket clientSocket = GssSocketFactory.getDefault().createSocket(host, port, context);
-        ((GssSocket)clientSocket).setWrapMode(GssSocket.GSI_MODE);
-        ((GssSocket)clientSocket).setAuthorization(NoAuthorization.getInstance());
-        return(clientSocket);
-    }
-
-    /**
-     * Returns the Globus formatted representation of the
-     * subject DN of the specified DN.
-     *
-     * @param dn the DN
-     * @return the Globus formatted representation of the
-     *         subject DN.
-     */
-    public static String toGlobusID(Vector dn) {
-
-        int len = dn.size();
-        StringBuffer buf = new StringBuffer();
-        for (int i=0;i<len;i++) {
-            Vector rdn = (Vector)dn.elementAt(i);
-            // checks only first ava entry
-            String [] ava = (String[])rdn.elementAt(0);
-            buf.append('/').append(ava[0]).append('=').append(ava[1]);
-        }
-        return buf.toString();
-    }
 
     /**
      * Converts the certificate dn into globus dn representation:
@@ -127,25 +57,15 @@ public class X509CertUtil {
      * @return globus dn representation
      */
     public static String toGlobusDN(String certDN) {
-        StringTokenizer tokens = new StringTokenizer(certDN, ",");
-        StringBuffer buf = new StringBuffer();
-        String token;
-
-        while(tokens.hasMoreTokens()) {
-            token = tokens.nextToken().trim();
-            buf.insert(0, token);
-            buf.insert(0, "/");
-        }
-
-        return buf.toString();
+        return OpensslNameUtils.convertFromRfc2253(certDN, true);
     }
 
     public static String getSubjectFromX509Chain(X509Certificate[] chain, boolean omitEmail) throws Exception {
-        return BouncyCastleUtil.getIdentity(chain);
+        return toGlobusDN(ProxyUtils.getOriginalUserDN(chain).getName());
     }
 
     public static X509Certificate getUserCertFromX509Chain(X509Certificate[] chain) throws Exception {
-        return BouncyCastleUtil.getIdentityCertificate(chain);
+        return ProxyUtils.getEndUserCertificate(chain);
     }
 
     public static Date getLatestNotBefore(X509Certificate[] chain) throws Exception {
@@ -158,13 +78,7 @@ public class X509CertUtil {
             }
 
             // No need to test certificate chain beyond the user cert
-            TBSCertificateStructure tbsCert  = BouncyCastleUtil.getTBSCertificateStructure(testcert);
-            //int certType = BouncyCastleUtil.getCertificateType(tbsCert);
-	    /* Change from cog-jglobus to jglobus 2.0 use getCertificate passing it the X509Certificate 
-	       and the getCertificateType is no longer an integer.
-	    */
-            int certType = BouncyCastleUtil.getCertificateType(testcert).getCode();
-            if (!org.globus.gsi.CertUtil.isImpersonationProxy(certType)) {
+            if (!ProxyUtils.isProxy(testcert)) {
                 break;
             }
         }
@@ -186,13 +100,7 @@ public class X509CertUtil {
             }
 
             // No need to test certificate chain beyond the user cert
-            TBSCertificateStructure tbsCert  = BouncyCastleUtil.getTBSCertificateStructure(testcert);
-            //int certType = BouncyCastleUtil.getCertificateType(tbsCert);
-	    /* Change from cog-jglobus to jglobus 2.0 use getCertificate passing it the X509Certificate
-               and the getCertificateType is no longer an integer. 
-	    */
-            int certType = BouncyCastleUtil.getCertificateType(testcert).getCode();
-            if (!org.globus.gsi.CertUtil.isImpersonationProxy(certType)) {
+            if (!ProxyUtils.isProxy(testcert)) {
                 break;
             }
         }
@@ -211,34 +119,6 @@ public class X509CertUtil {
 
     public static String getSubjectX509Issuer(X509Certificate cert) throws Exception {
        return toGlobusDN(cert.getIssuerDN().toString());
-    }
-
-    public static Collection<String> getFQANsFromContext(ExtendedGSSContext gssContext, boolean validate) throws Exception {
-        X509Certificate[] chain;
-        try {
-            chain = (X509Certificate[]) gssContext.inquireByOid(GSSConstants.X509_CERT_CHAIN);
-        } catch (GSSException gsse) {
-            throw new Exception("Could not extract certificate chain from context " + gsse.getMessage() + "\n" + gsse.getCause());
-        }
-        return getFQANsFromX509Chain(chain, validate);
-    }
-
-    public static Collection <String> getFQANsFromContext(ExtendedGSSContext gssContext) throws Exception {
-        X509Certificate[] chain;
-        try {
-            chain = (X509Certificate[]) gssContext.inquireByOid(GSSConstants.X509_CERT_CHAIN);
-        } catch (GSSException gsse) {
-            throw new Exception("Could not extract certificate chain from context " + gsse.getMessage() + "\n" + gsse.getCause());
-        }
-        return getFQANsFromX509Chain(chain, false);
-    }
-
-    public static Collection <String> getValidatedFQANsFromX509Chain(X509Certificate[] chain) throws Exception {
-        return getFQANsFromX509Chain(chain, true);
-    }
-
-    public static Collection <String> getFQANsFromX509Chain(X509Certificate[] chain) throws Exception {
-        return getFQANsFromX509Chain(chain, false);
     }
 
     public static Collection <String> getFQANsFromX509Chain(X509Certificate[] chain, boolean validate) throws Exception {
@@ -272,10 +152,10 @@ attribute : /cms/uscms/Role=cmsprod/Capability=NULL
         Iterator i = listOfAttributes.iterator();
         while (i.hasNext()) {
             VOMSAttribute vomsAttribute = (VOMSAttribute) i.next();
-            List listOfFqans = vomsAttribute.getFullyQualifiedAttributes();
-            Iterator j = listOfFqans.iterator();
+            List<String> listOfFqans = vomsAttribute.getFQANs();
+            Iterator<String> j = listOfFqans.iterator();
             while (j.hasNext()) {
-                String attr = (String) j.next();
+                String attr = j.next();
                 if(attr.endsWith(capnull))
                 attr = attr.substring(0, attr.length() - capnulllen);
                 if(attr.endsWith(rolenull))
@@ -293,10 +173,6 @@ attribute : /cms/uscms/Role=cmsprod/Capability=NULL
         return fqans;
     }
 
-    public static AttributeCertificate getAttributeCertificate(X509Certificate[] chain, String fqan) throws Exception {
-        return getVOMSAttribute(chain, fqan).getAC();
-    }
-
     public static VOMSAttribute getVOMSAttribute(X509Certificate[] chain, String fqan) throws Exception {
 
         if(fqan.endsWith(capnull))
@@ -309,10 +185,10 @@ attribute : /cms/uscms/Role=cmsprod/Capability=NULL
         Iterator i = listOfAttributes.iterator();
         while (i.hasNext()) {
             VOMSAttribute vomsAttribute = (VOMSAttribute) i.next();
-            List listOfFqans = vomsAttribute.getFullyQualifiedAttributes();
-            Iterator j = listOfFqans.iterator();
+            List<String> listOfFqans = vomsAttribute.getFQANs();
+            Iterator<String> j = listOfFqans.iterator();
             while (j.hasNext()) {
-                String attr = (String) j.next();
+                String attr = j.next();
                 String attrtmp=attr;
                 if(attrtmp.endsWith(capnull))
                     attrtmp = attrtmp.substring(0, attrtmp.length() - capnulllen);
@@ -331,16 +207,14 @@ attribute : /cms/uscms/Role=cmsprod/Capability=NULL
         return null;
     }
 
-    public static synchronized List getVOMSAttributes(X509Certificate[] chain, boolean validate) throws Exception {
+    public static List<VOMSAttribute> getVOMSAttributes(X509Certificate[] chain, boolean validate) throws Exception {
         try {
-            VOMSValidator validator = getVOMSValidatorInstance();
-            validator.setClientChain(chain);
-            if(validate) {
-                validator.validate();
+            VOMSACValidator validator = getVOMSValidatorInstance();
+            if (validate) {
+                return validator.validate(chain);
             } else {
-                validator.parse();
+                return validator.parse(chain);
             }
-            return validator.getVOMSAttributes();
         } catch (IOException ioe) {
             throw new Exception("Could not read trust stores " + ioe.getMessage() + "\n" + ioe.getCause());
         } catch (CertificateException ce) {
@@ -350,45 +224,40 @@ attribute : /cms/uscms/Role=cmsprod/Capability=NULL
         }
     }
 
-    public static String parseGroupFromFQAN(String fqan) {
-        String group=null;
-        if(fqan!=null) {
-            group = (new FQAN(fqan)).getGroup();
-            StringTokenizer st = new StringTokenizer(group, "/");
-            if (st.hasMoreTokens()) {
-                group = "/" + st.nextToken();
-            }
+    public static synchronized VOMSACValidator getVOMSValidatorInstance() throws IOException, CertificateException, CRLException {
+        if (vomsValidator == null) {
+            String vomsDir = System.getProperty("VOMSDIR");
+            VOMSTrustStore vomsTrustStore =
+                    (vomsDir == null)
+                            ? VOMSTrustStores.newTrustStore()
+                            : VOMSTrustStores.newTrustStore(asList(vomsDir));
+            X509CertChainValidatorExt certChainValidator = getCertChainValidator();
+            vomsValidator = VOMSValidators.newValidator(vomsTrustStore, certChainValidator);
         }
-        return group;
-    }
-
-    public static synchronized VOMSValidator getVOMSValidatorInstance() throws IOException, CertificateException, CRLException {
-        if(vomsValidator!=null) return vomsValidator;
-        PKIStore vomsStore=null;
-        String vomsDir = System.getProperty( "VOMSDIR" );
-        vomsDir = (vomsDir == null ) ? PKIStore.DEFAULT_VOMSDIR : vomsDir;
-        File theDir = new File(vomsDir);
-        if (theDir.exists() && theDir.isDirectory() && theDir.list().length > 0) {
-            vomsStore = new PKIStore(vomsDir, PKIStore.TYPE_VOMSDIR, true);
-            vomsStore.rescheduleRefresh(900000);
-        }
-
-        PKIStore caStore;
-        String caDir = System.getProperty( "CADIR" );
-        caDir = (caDir == null) ? PKIStore.DEFAULT_CADIR : caDir;
-        caStore = new PKIStore( caDir, PKIStore.TYPE_CADIR, true );
-        caStore.rescheduleRefresh(900000);
-
-        vomsValidator = new VOMSValidator(null, new ACValidator(new PKIVerifier(vomsStore, caStore)));
         return vomsValidator;
     }
 
-    public static synchronized ACTrustStore getACTrustStoreInstance() throws IOException, CertificateException, CRLException {
-        if(acTrustStore!=null) return acTrustStore;
-        acTrustStore = new BasicVOMSTrustStore(PKIStore.DEFAULT_CADIR, 12*3600*1000);
-        ((BasicVOMSTrustStore)acTrustStore).stopRefresh();
-        return acTrustStore;
+    public static synchronized X509CertChainValidatorExt getCertChainValidator()
+    {
+        if (certChainValidator == null) {
+            String caDir = System.getProperty("CADIR");
+            CertificateValidatorBuilder certificateValidatorBuilder = new CertificateValidatorBuilder();
+            if (caDir != null) {
+                certificateValidatorBuilder.trustAnchorsDir(caDir);
+            }
+            certChainValidator = certificateValidatorBuilder.build();
+        }
+        return certChainValidator;
     }
 
+    public static synchronized X509Credential getHostCredential() throws CertificateException, KeyStoreException, IOException
+    {
+        if (hostCredential == null) {
+            String hostkey = System.getProperty("HOSTKEY", default_service_key);
+            String hostcert = System.getProperty("HOSTCERT", default_service_cert);
+            hostCredential = new PEMCredential(hostkey, hostcert, null);
+        }
+        return hostCredential;
+    }
 }
 


### PR DESCRIPTION
Hi,

The first patch in this PR ports the XACMLClient to CANL. It drops a number of unused utility functions that relied on JGlobus. Some system properties may have changed as both JGlobus and the client lib reacted to various properties. The new version recognizes CADIR, VOMSDIR, HOSTKEY and HOSTCERT. All have the expected defaults.

The second patch applies a couple of Java 5 language features to clean up the code a little.

The library now compiles without manually having to install any dependencies first - everything needed appears in Maven central.

The version number is increased to 3.0.0-SNAPSHOT due to the API and property changes. I do not expect it to be difficult to port existing code to the new library - not unless the existing code made use of the unrelated utility functions that I dropped as part of the port. It is not a problem if existing code makes direct use of JGlobus as the version of CANL used can coexist with JGlobus (same version of bouncy castle).
